### PR TITLE
Fix working with null values

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,11 +4,10 @@ import shvl from 'shvl';
 const defaultReducer = (state, paths) =>
   paths.length === 0
     ? state
-    : paths.reduce(
-        (substate, path) =>
-          shvl.set(substate, path, shvl.get(state, path)) && substate,
-        {}
-      );
+    : paths.reduce((substate, path) => {
+        shvl.set(substate, path, shvl.get(state, path));
+        return substate;
+      }, {});
 
 const canWriteStorage = storage => {
   try {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,13 +2,13 @@ import merge from 'deepmerge';
 import shvl from 'shvl';
 
 const defaultReducer = (state, paths) =>
-  (paths.length === 0
+  paths.length === 0
     ? state
     : paths.reduce(
         (substate, path) =>
           shvl.set(substate, path, shvl.get(state, path)) && substate,
         {}
-      ));
+      );
 
 const canWriteStorage = storage => {
   try {
@@ -48,7 +48,7 @@ export default function createPersistedState(
   return store => {
     const savedState = getState(key, storage);
 
-    if (typeof savedState === 'object') {
+    if (typeof savedState === 'object' && savedState !== null) {
       store.replaceState(merge(store.state, savedState));
     }
 

--- a/src/plugin.spec.js
+++ b/src/plugin.spec.js
@@ -128,6 +128,26 @@ it('persist the changed partial state back to serialized JSON under a nested pat
   );
 });
 
+it('not persist null values', () => {
+  const storage = new Storage();
+  const store = new Store({
+    state: { alpha: { name: null, bravo: { name: null } } }
+  });
+
+  const plugin = createPersistedState({
+    storage,
+    paths: ['alpha.name', 'alpha.bravo.name']
+  });
+
+  plugin(store);
+
+  store._subscribers[0]('mutation', { charlie: { name: 'charlie' } });
+
+  expect(storage.getItem('vuex')).toBe(
+    JSON.stringify({ alpha: { bravo: {} } })
+  );
+});
+
 it("rehydrates store's state through the configured getter", () => {
   const storage = new Storage();
 

--- a/src/plugin.spec.js
+++ b/src/plugin.spec.js
@@ -38,6 +38,21 @@ it("does not replaces store's state when receiving invalid JSON", () => {
   expect(store.subscribe).toBeCalled();
 });
 
+it("does not replaces store's state when receiving null", () => {
+  const storage = new Storage();
+  storage.setItem('vuex', JSON.stringify(null));
+
+  const store = new Store({ state: { nested: { original: 'state' } } });
+  store.replaceState = jest.fn();
+  store.subscribe = jest.fn();
+
+  const plugin = createPersistedState({ storage });
+  plugin(store);
+
+  expect(store.replaceState).not.toBeCalled();
+  expect(store.subscribe).toBeCalled();
+});
+
 it("respects nested values when it replaces store's state on initializing", () => {
   const storage = new Storage();
   storage.setItem('vuex', JSON.stringify({ persisted: 'json' }));


### PR DESCRIPTION
A few of my vuex modules use `null` for initial state. This trips up vuex-persistedstate in 2 places: reading `'null'` from localStorage, reading null values from state. This didn't happen with `v2.0.0` but broke my application after switching to `v2.2.0` when starting with an empty localStorage.