### PR TITLE
Plugin can be created without passing empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const merge = require('deepmerge');
 const shvl = require('shvl');
 
 module.exports = function(options, storage, key) {
+  options = options || {};
   storage = options.storage || (window && window.localStorage);
   key = options.key || 'vuex';
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,11 @@ const createPersistedState = require('./index');
 
 Vue.use(Vuex);
 
+it('can be created with the default options', () => {
+  window.localStorage = new Storage();
+  expect(() => createPersistedState()).not.toThrow();
+});
+
 it("replaces store's state and subscribes to changes when initializing", () => {
   const storage = new Storage();
   storage.setItem('vuex', JSON.stringify({ persisted: 'json' }));


### PR DESCRIPTION
Accidentally I've forgot to set the default object when creating a plugin instance. Fixes #79 and closes #81.