### PR TITLE
Overwrite array values instead of merging them

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ module.exports = function(options, storage, key) {
     var savedState = shvl.get(options, 'getState', getState)(key, storage);
 
     if (typeof savedState === 'object' && savedState !== null) {
-      store.replaceState(merge(store.state, savedState));
+      store.replaceState(merge(store.state, savedState, {
+        arrayMerge: function (store, saved) { return saved }
+      }));
     }
 
     (options.subscriber || subscriber)(store)(function(mutation, state) {

--- a/test.js
+++ b/test.js
@@ -153,6 +153,23 @@ it('not persist null values', () => {
   );
 });
 
+it('persist array values', () => {
+  const storage = new Storage();
+  storage.setItem('vuex', JSON.stringify({ persisted: ['json'] }));
+
+  const store = new Vuex.Store({ state: { persisted: ['state'] } });
+  store.replaceState = jest.fn();
+  store.subscribe = jest.fn();
+
+  const plugin = createPersistedState({ storage });
+  plugin(store);
+
+  expect(store.replaceState).toBeCalledWith({
+    persisted: ['json'],
+  });
+  expect(store.subscribe).toBeCalled();
+});
+
 it("rehydrates store's state through the configured getter", () => {
   const storage = new Storage();
 


### PR DESCRIPTION
Before with this plugin, the default array values in the store would be overwritten by the saved localStorage array values (because it was using lodash.merge.) For example, the provided test in this PR passes in version 2.1.2.

The test fails on current master, because with deepmerge the default behavior is different as it really merges array values. So if I got a default state of: testArray: ['hello'] - and I use this plugin and reload the page 3 times, I got ['hello', 'hello', hello']

So it is better to really overwrite the array like before, this PR should do that.

edit: upon closer looking lodash.merge simply treats it as a object with numeric keys, so it would be overwritten as long as the saved array had more/equal items than the default array. Either way, completely overwriting seems to be the preferred way to me.