### PR TITLE
Added es as default module / esnext output

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/robinvdvleuten/vuex-persistedstate/issues"
   },
   "main": "dist/vuex-persistedstate.js",
-  "module": "index.js",
-  "jsnext:main": "index.js",
+  "module": "dist/vuex-persistedstate.es.js",
+  "jsnext:main": "dist/vuex-persistedstate.es.js",
   "umd:main": "dist/vuex-persistedstate.umd.js",
   "files": [
     "dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ export default {
 	],
 	output: [
 		{ file: pkg.main, format: 'cjs' },
+		{ file: pkg.module, format: 'es' },
 		{ file: pkg['umd:main'], format: 'umd', name: 'createPersistedState' }
 	]
 };


### PR DESCRIPTION
As mentioned by issues #97 and #83, all occurrences of `const` must be replaced by `var`.