### PR TITLE
Make merging of arrays customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ can be provided to configure the plugin for your specific needs:
 - `getState <Function>`: A function that will be called to rehydrate a previously persisted state. Defaults to using `storage`.
 - `setState <Function>`: A function that will be called to persist the given state. Defaults to using `storage`.
 - `filter <Function>`: A function that will be called to filter any mutations which will trigger `setState` on storage eventually. Defaults to `() => true`
+- `arrayMerger <Function>`: A function for merging arrays when rehydrating state. Defaults to `function (store, saved) { return saved }` (saved state replaces supplied state).
 
 ## Customize Storage
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ export default function(options, storage, key) {
 
     if (typeof savedState === 'object' && savedState !== null) {
       store.replaceState(merge(store.state, savedState, {
-        arrayMerge: function (store, saved) { return saved },
+        arrayMerge: options.arrayMerger || function (store, saved) { return saved },
         clone: false,
       }));
     }

--- a/test.js
+++ b/test.js
@@ -156,7 +156,7 @@ it('should not persist null values', () => {
   );
 });
 
-it('should not merge array values when rehydrating', () => {
+it('should not merge array values when rehydrating by default', () => {
   const storage = new Storage();
   storage.setItem('vuex', JSON.stringify({ persisted: ['json'] }));
 
@@ -191,6 +191,27 @@ it('should not clone circular objects when rehydrating', () => {
   expect(store.replaceState).toBeCalledWith({
     circular,
     persisted: 'baz',
+  });
+
+  expect(store.subscribe).toBeCalled();
+});
+
+it('should apply a custom arrayMerger function', () => {
+  const storage = new Storage();
+  storage.setItem('vuex', JSON.stringify({ persisted: [1, 2] }));
+
+  const store = new Vuex.Store({ state: { persisted: [1, 2, 3] } });
+  store.replaceState = jest.fn();
+  store.subscribe = jest.fn();
+
+  const plugin = createPersistedState({ 
+    storage,
+    arrayMerger: function (store, saved) { return ['hello!'] },
+   });
+  plugin(store);
+
+  expect(store.replaceState).toBeCalledWith({
+    persisted: ['hello!'],
   });
 
   expect(store.subscribe).toBeCalled();


### PR DESCRIPTION
As noted in deepmerge's documentation there are many ways to merge an array. This pull request enables the library's users to customize the way arrays are merged when rehydrating state (also see #54).