### PR TITLE
Add 'overwrite' option to bypass object merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ can be provided to configure the plugin for your specific needs:
 * `getState <Function>`: A function that will be called to rehydrate a previously persisted state. Defaults to using `storage`.
 * `setState <Function>`: A function that will be called to persist the given state. Defaults to using `storage`.
 * `filter <Function>`: A function that will be called to filter any mutations which will trigger `setState` on storage eventually. Defaults to `() => true`
+* `overwrite <Boolean>`: When rehydrating, whether to overwrite the existing state with the output from `getState` directly, instead of merging the two objects with `deepmerge`. Defaults to false.
 * `arrayMerger <Function>`: A function for merging arrays when rehydrating state. Defaults to `function (store, saved) { return saved }` (saved state replaces supplied state).
 
 ## Customize Storage

--- a/index.js
+++ b/index.js
@@ -56,10 +56,14 @@ export default function(options, storage, key) {
     const savedState = shvl.get(options, 'getState', getState)(key, storage);
 
     if (typeof savedState === 'object' && savedState !== null) {
-      store.replaceState(merge(store.state, savedState, {
-        arrayMerge: options.arrayMerger || function (store, saved) { return saved },
-        clone: false,
-      }));
+      if (options.overwrite) {
+        store.replaceState(savedState);
+      } else {
+        store.replaceState(merge(store.state, savedState, {
+          arrayMerge: options.arrayMerger || function (store, saved) { return saved },
+          clone: false,
+        }));
+      }
     }
 
     (options.subscriber || subscriber)(store)(function(mutation, state) {


### PR DESCRIPTION
We're trying to write an application which overrides getState and setState in order to add some more complex serialization logic, but got stymied by the use of deepmerge (which has undefined results for anything outside the JSON compatible subset). In our case we're loading state information into a JS Map object, but this would apply to any data structure that's not JSON compatible. 

Given the objects are freshly created, an easy workaround is to just overwrite the existing state object with the getState object instead of merging; this PR adds an optional flag for this.