### PR TITLE
readme: Improve Nuxt.js example to support nuxt generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ plugins: [{ src: '~/plugins/localStorage.js', ssr: false }]
 import createPersistedState from 'vuex-persistedstate'
 
 export default ({store}) => {
-  createPersistedState({
-      key: 'yourkey',
-      paths: [...]
-      ...
-  })(store)
+  window.onNuxtReady(() => {
+    createPersistedState({
+        key: 'yourkey',
+        paths: [...]
+        ...
+    })(store)
+  })
 }
 ```
 


### PR DESCRIPTION
Hey @robinvdvleuten 

Great job on vuex-persistedstate :)

Actually, it's better if the store is updated after mounting the application to avoid some errors like this one in production:

```
Error while initializing app DOMException: Failed to execute 'appendChild' on 'Node': This node type does not support this method.
```