### PR TITLE
arrayMerger should be merger, because it can merge not only arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ can be provided to configure the plugin for your specific needs:
 - `getState <Function>`: A function that will be called to rehydrate a previously persisted state. Defaults to using `storage`.
 - `setState <Function>`: A function that will be called to persist the given state. Defaults to using `storage`.
 - `filter <Function>`: A function that will be called to filter any mutations which will trigger `setState` on storage eventually. Defaults to `() => true`
-- `arrayMerger <Function>`: A function for merging arrays when rehydrating state. Defaults to `function (store, saved) { return saved }` (saved state replaces supplied state).
+- `merger <Function>`: A function for merging when rehydrating state. Defaults to `function (store, saved) { return saved }` (saved state replaces supplied state).
 
 ## Customize Storage
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ interface Options {
     getState?: (key: string, storage: Storage) => any;
     setState?: (key: string, state: typeof Store, storage: Storage) => void;
     filter?: (mutation: MutationPayload) => boolean;
+    merger?: (state: any, saved: any) => any;
 }
 
 export default function createPersistedState(options?: Options): any;

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ export default function(options, storage, key) {
 
     if (typeof savedState === 'object' && savedState !== null) {
       store.replaceState(merge(store.state, savedState, {
-        arrayMerge: options.arrayMerger || function (store, saved) { return saved },
+        arrayMerge: options.merger || function (store, saved) { return saved },
         clone: false,
       }));
     }

--- a/test.js
+++ b/test.js
@@ -196,7 +196,7 @@ it('should not clone circular objects when rehydrating', () => {
   expect(store.subscribe).toBeCalled();
 });
 
-it('should apply a custom arrayMerger function', () => {
+it('should apply a custom merger function', () => {
   const storage = new Storage();
   storage.setItem('vuex', JSON.stringify({ persisted: [1, 2] }));
 
@@ -206,7 +206,7 @@ it('should apply a custom arrayMerger function', () => {
 
   const plugin = createPersistedState({ 
     storage,
-    arrayMerger: function (store, saved) { return ['hello!'] },
+    merger: function (store, saved) { return ['hello!'] },
    });
   plugin(store);
 


### PR DESCRIPTION
This is a PR that proposes to change the naming from `arrayMerger` to just `merger`.

Please correct me if I'm missing something, but clearly the function can take any saved state and restore any other state. I have no idea what arrays have to do with anything.