### PR TITLE
Handle dynamically registered modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,9 @@ export default function(options, storage, key) {
     throw new Error('Invalid storage instance given');
   }
 
+  const savedState = shvl.get(options, 'getState', getState)(key, storage);
+
   return function(store) {
-    const savedState = shvl.get(options, 'getState', getState)(key, storage);
 
     if (typeof savedState === 'object' && savedState !== null) {
       store.replaceState(merge(store.state, savedState, {


### PR DESCRIPTION
We could handle dynamically registered modules just getting saved state during plugin initialization:
 
```
diff --git a/index.js b/index.js
index 257a9ed..16578f4 100644
--- a/index.js
+++ b/index.js
@@ -52,8 +52,9 @@ export default function(options, storage, key) {
     throw new Error('Invalid storage instance given');
   }
 
+  const savedState = shvl.get(options, 'getState', getState)(key, storage);
+
   return function(store) {
-    const savedState = shvl.get(options, 'getState', getState)(key, storage);
 
     if (typeof savedState === 'object' && savedState !== null) {
       store.replaceState(merge(store.state, savedState, {
```

We just have to initialize the plugin before store creation, then bind plugin after :

```
import createPersistedState from 'vuex-persistedstate'
const persistatedStore = createPersistedState(someOptions)

const store = new Vuex.Store({ ... })
store.registerModule('someModule', someModule)
persistatedStore(store)

```
