### PR TITLE
Add .d.ts for Options.fetchBeforeUse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ interface Options {
     filter?: (mutation: MutationPayload) => boolean;
     arrayMerger?: (state: any, saved: any) => any;
     rehydrated?: (store: typeof Store) => void;
+    fetchBeforeUse?: boolean; 
 }
 
 export default function createPersistedState(options?: Options): any;


### PR DESCRIPTION
This corresponds to the new option introduced in v2.7.1 by: https://github.com/robinvdvleuten/vuex-persistedstate/commit/24aff6980df301d1815ab513e0b64ae85c5abc79