### PR TITLE
Made paths accept null

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ export default function(options, storage, key) {
   }
 
   function reducer(state, paths) {
-    return paths.length === 0
+    return paths === null || paths === undefined
       ? state
       : paths.reduce(function(substate, path) {
           return shvl.set(substate, path, shvl.get(state, path));
@@ -67,14 +67,16 @@ export default function(options, storage, key) {
 
     if (typeof savedState === "object" && savedState !== null) {
       store.replaceState(
-        options.overwrite ? savedState : merge(store.state, savedState, {
-          arrayMerge:
-            options.arrayMerger ||
-            function(store, saved) {
-              return saved;
-            },
-          clone: false
-        })
+        options.overwrite
+          ? savedState
+          : merge(store.state, savedState, {
+              arrayMerge:
+                options.arrayMerger ||
+                function(store, saved) {
+                  return saved;
+                },
+              clone: false
+            })
       );
       (options.rehydrated || function() {})(store);
     }
@@ -83,7 +85,7 @@ export default function(options, storage, key) {
       if ((options.filter || filter)(mutation)) {
         (options.setState || setState)(
           key,
-          (options.reducer || reducer)(state, options.paths || []),
+          (options.reducer || reducer)(state, options.paths),
           storage
         );
       }

--- a/test.js
+++ b/test.js
@@ -358,3 +358,17 @@ it("fetches state from storage before the plugin is used", () => {
     persisted: "before"
   });
 });
+
+it("should not persist whole store if paths array is empty", () => {
+  const storage = new Storage();
+  const store = new Vuex.Store({
+    state: { original: "state" }
+  });
+
+  const plugin = createPersistedState({ storage, paths: [] });
+  plugin(store);
+
+  store._subscribers[0]("mutation", { changed: "state" });
+
+  expect(storage.getItem("vuex")).toBe(JSON.stringify({}));
+});


### PR DESCRIPTION
**What**: Made `paths` accept `null` as value instead of an empty array.

**Why**: See https://github.com/robinvdvleuten/vuex-persistedstate/issues/238

**How**: Removed `options.paths` default to `[]`. Also added a check for `paths == null`

**Checklist**:

- [ ] Documentation (Not done. At further though this might be necessary though. I'd like your opinion)
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table (Shouldn't this be done though All Contributors Bot?)

<!-- feel free to add additional comments -->
