### PR TITLE
[bug] storage and key parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,13 @@ interface Options {
 }
 
 export default function (
-  options: Options | null,
-  storage: Storage | null,
-  key: string | null
+  options?: Options | null,
+  storage?: Storage | null,
+  key?: string | null
 ) {
   options = options || {};
-  storage = options.storage || (window && window.localStorage);
-  key = options.key || "vuex";
+  storage = options.storage || storage || (window && window.localStorage);
+  key = options.key || key || "vuex";
 
   function getState(key, storage) {
     let value;


### PR DESCRIPTION
## PR: `storage` and `key` parameters
### Issue: https://github.com/robinvdvleuten/vuex-persistedstate/issues/257

Those parameters are no longer mandatory and are now working