### PR TITLE
Add generic for store state type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,9 @@ interface Options<State> {
   assertStorage?: (storage: Storage) => void | Error;
 }
 
-export default function <State>(options?: Options<State>) {
+export default function <State>(
+  options?: Options<State>
+): (store: Store<State>) => void {
   options = options || {};
 
   const storage = options.storage || (window && window.localStorage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,25 +8,25 @@ interface Storage {
   removeItem: (key: string) => void;
 }
 
-interface Options {
+interface Options<State> {
   key?: string;
   paths?: string[];
   reducer?: (state: any, paths: string[]) => object;
   subscriber?: (
-    store: typeof Store
+    store: Store<State>
   ) => (handler: (mutation: any, state: any) => void) => void;
   storage?: Storage;
   getState?: (key: string, storage: Storage) => any;
-  setState?: (key: string, state: typeof Store, storage: Storage) => void;
+  setState?: (key: string, state: Store<State>, storage: Storage) => void;
   filter?: (mutation: MutationPayload) => boolean;
   arrayMerger?: (state: any, saved: any) => any;
-  rehydrated?: (store: typeof Store) => void;
+  rehydrated?: (store: Store<State>) => void;
   fetchBeforeUse?: boolean;
   overwrite?: boolean;
   assertStorage?: (storage: Storage) => void | Error;
 }
 
-export default function (options?: Options) {
+export default function <State>(options?: Options<State>) {
   options = options || {};
 
   const storage = options.storage || (window && window.localStorage);


### PR DESCRIPTION
**What**:

Fixes #265 
As suggested by @robertgr991
Use type inference benefits when using a function like `rehydrated`

**Why**:

When implementing a function like `rehydrated` the store argument is currently typed as `any`.

**How**:

By adding a generic type when calling the `createPersistedState` function
```ts
const persisted = createPersistedState<RootState>();
```
**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table
