### PR TITLE
Fixing Typescript generic inconsistencies and "arrayMerger" parameters types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,15 @@ interface Storage {
 interface Options<State> {
   key?: string;
   paths?: string[];
-  reducer?: (state: any, paths: string[]) => object;
+  reducer?: (state: State, paths: string[]) => object;
   subscriber?: (
     store: Store<State>
-  ) => (handler: (mutation: any, state: any) => void) => void;
+    ) => (handler: (mutation: any, state: State) => void) => void;
   storage?: Storage;
   getState?: (key: string, storage: Storage) => any;
-  setState?: (key: string, state: Store<State>, storage: Storage) => void;
+  setState?: (key: string, state: any, storage: Storage) => void;
   filter?: (mutation: MutationPayload) => boolean;
-  arrayMerger?: (state: any, saved: any) => any;
+  arrayMerger?: (state: any[], saved: any[]) => any;
   rehydrated?: (store: Store<State>) => void;
   fetchBeforeUse?: boolean;
   overwrite?: boolean;
@@ -85,7 +85,7 @@ export default function <State>(
     savedState = fetchSavedState();
   }
 
-  return function (store) {
+  return function (store: Store<State>) {
     if (!options.fetchBeforeUse) {
       savedState = fetchSavedState();
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

After merging the pull request for generic state, there are some parameters that are not correctly typed.

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

The `state` parameter in `setState` method should not be typed as `Store<State>` because if only a part of the store state is persisted, for example, just a module, the `state` parameter will have the value of that module object, not of the entire store state, therefore, the state should be typed as `any`.

On the other hand, the reducer and subscriber receives the complete state so their `state` params should be typed as `state: State`.

Also I've seen that the `arrayMerger` method is used in `deepmerge` package only on arrays, so the parameters should be typed as `any[]`.

**How**:

<!-- Have you done all of these things?  -->

Fixing the parameters type.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Let me know what you think about this. I've used your package with this changes and to me it seems like this are the correct typings and it behave as expected.