### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export const dataStore = {
 import { dataStore } from './module'
 
 const dataState = new createPersistedState({
-  paths: 'data'
+  paths: ['data']
 })
 
 export new Vuex.Store({


### PR DESCRIPTION
**What**:

Updates the usage of `paths` in the README example

**Why**:

The `Options` interface defines `paths` as an array of strings, but the example shows it as a single string. By following the example verbatim users end up persisting their entire state when they think they're using selected paths

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A
