### PR TITLE
add event for external tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ can be provided to configure the plugin for your specific needs:
 - `reducer <Function>`: A function that will be called to reduce the state to persist based on the given paths. Defaults to include the values.
 - `subscriber <Function>`: A function called to setup mutation subscription. Defaults to `store => handler => store.subscribe(handler)`.
 
-- `storage <Object>`: Instead of (or in combination with) `getState` and `setState`. Defaults to localStorage.
+- `storage <Object>`: Instead of (or in combination with) `getState` and `setState`. Defaults to `localStorage`.
 - `getState <Function>`: A function that will be called to rehydrate a previously persisted state. Defaults to using `storage`.
 - `setState <Function>`: A function that will be called to persist the given state. Defaults to using `storage`.
 - `filter <Function>`: A function that will be called to filter any mutations which will trigger `setState` on storage eventually. Defaults to `() => true`.
@@ -133,6 +133,7 @@ can be provided to configure the plugin for your specific needs:
 - `rehydrated <Function>`: A function that will be called when the rehydration is finished. Useful when you are using Nuxt.js, which the rehydration of the persisted state happens asynchronously. Defaults to `store => {}`
 - `fetchBeforeUse <Boolean>`: A boolean indicating if the state should be fetched from storage before the plugin is used. Defaults to `false`.
 - `assertStorage <Function>`: An overridable function to ensure storage is available, fired on plugins's initialization. Default one is performing a Write-Delete operation on the given Storage instance. Note, default behaviour could throw an error (like `DOMException: QuotaExceededError`).
+- `syncTabs <Boolean>`: Whether or not to sync state across tabs, by listening to `window`'s `storage` Event and triggering a new `setState` with the recieved event value (meaning the state was changed in other window). Defaults to `false` for backwards compatibility with custom `storage` instances.
 
 ## Customize Storage
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@types/jest": "^26.0.4",
     "all-contributors-cli": "^6.9.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^25.1.0",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 import Vue from "vue";
 import Vuex from "vuex";
 import Storage from "dom-storage";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Implementation for proposal described in #287.

**Why**:

<!-- How were these changes implemented? -->

Resolves #287.

**How**:

<!-- Have you done all of these things?  -->

The [`storage` Event](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent) is triggered when there is a change **in other tabs** with the same Storage instance.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

- - -
**Note**: I failed to add tests to this feature :(, so I'm leaving 2 checkboxes unchecked waiting to receive some pointers if anyone has any idea! 

PD: I added jest explicit types in the test file for better autocompletion and an explicit dependency of those.