### PR TITLE
Moved `storage.getItem` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,10 @@ export default function <State>(
   const key = options.key || "vuex";
 
   function getState(key, storage) {
-    let value;
+    const value = storage.getItem(key);
 
     try {
-      return (value = storage.getItem(key)) && typeof value !== "undefined"
+      return (typeof value !== "undefined")
         ? JSON.parse(value)
         : undefined;
     } catch (err) {}


### PR DESCRIPTION
Moved `storage.getItem` function call outside of silent `try {} catch {}`.

The silent `try {} catch {}` block was hiding an error from appearing, a mistake I was making inside my `getItem` function, so I didn't understand what was going on.

I understand the `try {} catch {}` block is there to hide a `JSON.parse` error,
so I left this one inside it.
