### PR TITLE
Prevent JSON.parse to be called with a non string value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ export default function <State>(
     const value = storage.getItem(key);
 
     try {
-      return (typeof value !== "undefined")
-        ? JSON.parse(value)
-        : undefined;
+      return (typeof value === "string")
+        ? JSON.parse(value) : (typeof value === "object")
+        ? value : undefined;
     } catch (err) {}
 
     return undefined;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Prevent JSON.parse to be called with a non string value

<!-- Why are these changes necessary? -->

**Why**: Sometimes (non standard storages) the item provided by getItem method is already of Object type. 

<!-- How were these changes implemented? -->

**How**: In general, JSON parse needs to be called with a string parameter, if this is satisfied, do it. If not, check if it is already a Object, and if it is, return it. Otherwise, return undefined.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
