### PR TITLE
docs(readme): add instructions for Nuxt Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,47 @@ export default ({ store, req }) => {
 };
 ```
 
+#### Using Nuxt Bridge with cookies (universal client + server-side)
+
+Add `cookie`:
+
+`npm install --save cookie`
+or `yarn add cookie`
+
+```typescript
+// nuxt.config.ts
+...
+plugins: ['~/plugins/persistedState.js']
+...
+```
+
+```typescript
+// ~/plugins/persistedState.ts
+
+import { Context } from '@nuxt/types'
+import createPersistedState from 'vuex-persistedstate'
+import Cookies from 'js-cookie'
+import { useCookie } from 'h3'
+
+export default ({ store, req }: Context) => {
+  createPersistedState({
+    paths: ['participationData'],
+    storage: {
+      getItem: (key) => {
+        if (process.server) {
+          return useCookie(req, key)
+        } else {
+          return Cookies.get(key)
+        }
+      },
+      setItem: (key, value) =>
+        Cookies.set(key, value, { expires: 365, secure: true }),
+      removeItem: (key) => Cookies.remove(key),
+    },
+  })(store)
+}
+```
+
 ## API
 
 ### `createPersistedState([options])`


### PR DESCRIPTION
**What**:

I've added documentation on how to use this module with Nuxt Bridge.

**Why**:

The underlying webserver changed to h3 in Nuxt's new Nitro engine, making usage of js-cookie unnecessary! One now **has** to use h3's `useCookie` method.

**How**:

Works like this in a project of mine.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table
